### PR TITLE
OTLP 

### DIFF
--- a/node/src/config.ts
+++ b/node/src/config.ts
@@ -30,6 +30,19 @@ export interface ServerConfig {
   host: string;
 }
 
+export interface OtlpConfig {
+  /** OTLP endpoint base URL — e.g. https://otlp-gateway-prod-us-east-0.grafana.net/otlp */
+  endpoint: string;
+  /** Auth + custom headers — e.g. { "Authorization": "Basic <base64>" } */
+  headers?: Record<string, string>;
+  /** Metrics push interval in seconds (default: 30) */
+  intervalSeconds?: number;
+  /** Export metrics (default: true) */
+  metrics?: boolean;
+  /** Export alert logs (default: true) */
+  logs?: boolean;
+}
+
 export interface AppConfig {
   /** OpenClaw gateway WebSocket URL */
   gatewayUrl: string;
@@ -49,6 +62,8 @@ export interface AppConfig {
   quiet?: boolean;
   /** Hourly alert cap (default 10) */
   maxAlertsPerHour?: number;
+  /** OTLP export config — disabled if omitted */
+  otlp?: OtlpConfig;
 }
 
 const DEFAULTS: AppConfig = {

--- a/node/src/core/engine.ts
+++ b/node/src/core/engine.ts
@@ -34,6 +34,7 @@ export class OpenAlertsEngine {
   private running = false;
   private eventRing: OpenAlertsEvent[] = [];
   private static readonly RING_MAX = 500;
+  private alertCallbacks: ((alert: AlertEvent) => void)[] = [];
 
   constructor(options: OpenAlertsInitOptions & { db?: DatabaseSync | null }) {
     this.config = options.config;
@@ -117,6 +118,11 @@ export class OpenAlertsEngine {
 
   get isRunning(): boolean { return this.running; }
 
+  /** Register a callback that fires every time an alert is dispatched. */
+  onAlert(cb: (alert: AlertEvent) => void): void {
+    this.alertCallbacks.push(cb);
+  }
+
   getRecentEvents(limit = 100): StoredEvent[] { return readRecentEvents(this.stateDir, limit); }
   getRecentLiveEvents(limit = 200): OpenAlertsEvent[] { return this.eventRing.slice(-limit); }
 
@@ -181,5 +187,6 @@ export class OpenAlertsEngine {
     }
 
     this.logger.info(`${this.logPrefix}: [${alert.severity}] ${alert.title}`);
+    for (const cb of this.alertCallbacks) { try { cb(alert); } catch { /* ignore */ } }
   }
 }


### PR DESCRIPTION
  To enable, add to ~/.openalerts/config.json:

```
  {
    "otlp": {
      "endpoint": "https://otlp-gateway-prod-us-east-0.grafana.net/otlp",
      "headers": { "Authorization": "Basic <your-base64-token>" },
      "intervalSeconds": 30
    }
  }
```

  Metrics exported (every 30s): messages.processed, tokens.total, cost.usd, tool.calls/errors, agent.starts/errors, sessions.started,
  alerts.hourly, uptime.seconds, gateway.connected

  Logs exported (on each alert fire): rule_id, title, detail, severity, fingerprint — straight into Loki/Grafana.